### PR TITLE
Disable 'delivery.report.ony.error' on callbacks.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.1.6 (2017-07-04)
+------------------
+
+* Disable `delivery.report.ony.error` on callbacks because of a bug in
+`confluent-kafka`: https://github.com/confluentinc/confluent-kafka-python/issues/84
+Let's revisit when 0.11 is released.
+
 0.1.5 (2017-07-03)
 ------------------
 

--- a/tests/test_kafkadriver.py
+++ b/tests/test_kafkadriver.py
@@ -44,8 +44,9 @@ class TestKafkaDestination(unittest.TestCase):
             {'api.version.request': False,
              'bootstrap.servers': conf['hosts'],
              'broker.version.fallback': DEFAULT_BROKER_VERSION_FALLBACK,
-             'delivery.report.only.error': True,
-             'on_delivery': dest._acked})
+             # 'delivery.report.only.error': True,
+             # 'on_delivery': dest._acked
+             })
 
     def test_z_producer_config(self):
         dest = KafkaDestination()
@@ -119,8 +120,9 @@ class TestKafkaDestination(unittest.TestCase):
             {'api.version.request': False,
              'bootstrap.servers': conf['hosts'],
              'broker.version.fallback': DEFAULT_BROKER_VERSION_FALLBACK,
-             'delivery.report.only.error': True,
-             'on_delivery': dest._acked})
+             # 'delivery.report.only.error': True,
+             # 'on_delivery': dest._acked
+             })
 
         # multiple programs
         dest = KafkaDestination()
@@ -138,8 +140,9 @@ class TestKafkaDestination(unittest.TestCase):
             {'api.version.request': False,
              'bootstrap.servers': conf['hosts'],
              'broker.version.fallback': DEFAULT_BROKER_VERSION_FALLBACK,
-             'delivery.report.only.error': True,
-             'on_delivery': dest._acked})
+             # 'delivery.report.only.error': True,
+             # 'on_delivery': dest._acked
+             })
 
         # multiple programs with space after coma.
         dest = KafkaDestination()
@@ -157,8 +160,9 @@ class TestKafkaDestination(unittest.TestCase):
             {'api.version.request': False,
              'bootstrap.servers': conf['hosts'],
              'broker.version.fallback': DEFAULT_BROKER_VERSION_FALLBACK,
-             'delivery.report.only.error': True,
-             'on_delivery': dest._acked})
+             # 'delivery.report.only.error': True,
+             # 'on_delivery': dest._acked
+             })
 
     def test_init_group_config(self):
         dest = KafkaDestination()
@@ -176,9 +180,10 @@ class TestKafkaDestination(unittest.TestCase):
             {'api.version.request': False,
              'bootstrap.servers': conf['hosts'],
              'broker.version.fallback': DEFAULT_BROKER_VERSION_FALLBACK,
-             'delivery.report.only.error': True,
+             # 'delivery.report.only.error': True,
              'group.id': conf['group_id'],
-             'on_delivery': dest._acked})
+             # 'on_delivery': dest._acked
+             })
 
     def test_init_verbose_config(self):
         dest_msg = KafkaDestination()


### PR DESCRIPTION
Bug in 'confluent-kafka': https://github.com/confluentinc/confluent-kafka-python/issues/84

Let's revisit when 0.11 is released.